### PR TITLE
Added additional configuration parameters for Synchronous logging 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 CMakeLists.txt.user
+cmake/*

--- a/Essentials/pLogger/MOOSLogger.cpp
+++ b/Essentials/pLogger/MOOSLogger.cpp
@@ -124,6 +124,15 @@ CMOOSLogger::CMOOSLogger()
 	//by default do not indicate data tyep with a D: or S: suffix
 	m_bMarkDataType = false;
 
+    //by default, space header lines by 30 entries between
+    m_nSyncLogHeaderSpacing = 30;
+
+    //by default, insert intermediate headers into sync logs
+    m_bAddIntermediateHeaders = true;
+
+    //by default, replace stale variables with NaN
+    m_bIncludeStale = false;
+
     //lets always sort mail by time...
     SortMailByTime(true);
 
@@ -275,6 +284,12 @@ bool CMOOSLogger::OnStartUp()
     m_MissionReader.GetConfigurationParam("MarkExternalCommunityMessages",m_bMarkExternalCommunityMessages);
 
     m_MissionReader.GetConfigurationParam("MarkDataType",m_bMarkDataType);
+
+    m_MissionReader.GetConfigurationParam("SyncLogHeaderSpacing", m_nSyncLogHeaderSpacing);
+    
+    m_MissionReader.GetConfigurationParam("SyncLogIntermediateHeaders", m_bAddIntermediateHeaders);
+
+    m_MissionReader.GetConfigurationParam("IncludeStaleVariables", m_bIncludeStale);
 
     //do we have a path global name?
     if(!m_MissionReader.GetValue("GLOBALLOGPATH",m_sPath))
@@ -732,7 +747,7 @@ bool CMOOSLogger::DoSyncLog(double dfTimeNow)
             m_SyncLogFile<<setw(COLUMN_WIDTH);
 
             //has this variable changed since last time?
-            if(rVar.IsFresh())
+            if(rVar.IsFresh() || m_bIncludeStale)
             {
                 //we can only write doubles
                 if(rVar.IsDouble())
@@ -772,8 +787,11 @@ bool CMOOSLogger::DoSyncLog(double dfTimeNow)
     m_SyncLogFile<<endl;
 
     //every few lines put a comment in
-    if((m_nSyncLines++)%30==0)
-        LabelSyncColumns();
+    if (m_bAddIntermediateHeaders) 
+    {
+        if((m_nSyncLines++)%m_nSyncLogHeaderSpacing==0)
+            LabelSyncColumns();
+    }
 
     return true;
 }

--- a/Essentials/pLogger/MOOSLogger.h
+++ b/Essentials/pLogger/MOOSLogger.h
@@ -150,6 +150,15 @@ protected:
 	//.true if we want to log AuxSrc varaibles
 	bool m_bLogAuxSrc;
 
+    //true if we want headers inserted every x lines
+    bool m_bAddIntermediateHeaders;
+    
+    //sets how often headers are added
+    int m_nSyncLogHeaderSpacing;
+
+    //true if want stale varables to not be changed to NaN
+    bool m_bIncludeStale;
+
     //housekeeping  variables for performing tasks
     double m_dfLastSyncLogTime;
     double m_dfSyncLogPeriod;


### PR DESCRIPTION
I added three configuration parameters for synchronous logging:

**SyncLogIntermediateHeaders:** Controls whether the intermediate header/time lines are printed ever so often.  When turned off, it allows for easier analysis in Excel or graphing programs.
**SyncLogHeaderSpacing:** If headings are to be inserted (as per the above option), this determines how often they will be placed.
**IncludeStaleVariables:** Prints the previous value of non-updated variables instead of NaN.  Again makes for easier analysis in Excel or numerical analysis programs.

By default, if no configuration is in the .moos file, all options go to the state of configuration before these code changes, i.e. stale variables are replaced with NaN, headers placed every 30 lines.  Therefore, someone upgrading and not changing configurations would not see any changes.

