### PR TITLE
Update GetPot include path to match libMOOS contents

### DIFF
--- a/Essentials/pShare/Share.cpp
+++ b/Essentials/pShare/Share.cpp
@@ -17,7 +17,7 @@
 
 #include "MOOS/libMOOS/Utils/MOOSUtilityFunctions.h"
 #include "MOOS/libMOOS/Utils/IPV4Address.h"
-#include "MOOS/libMOOS/Thirdparty/getpot/getpot.h"
+#include "MOOS/libMOOS/Thirdparty/getpot/GetPot"
 #include "MOOS/libMOOS/Utils/SafeList.h"
 #include "MOOS/libMOOS/Utils/ConsoleColours.h"
 #include "MOOS/libMOOS/Utils/KeyboardCapture.h"


### PR DESCRIPTION
This fixes a bug where libMOOS has changed and broken pShare build as it can't find "getpot.h"