### PR TITLE
Resolve issue with pShare test copy target in cmake

### DIFF
--- a/Essentials/pShare/CMakeLists.txt
+++ b/Essentials/pShare/CMakeLists.txt
@@ -14,12 +14,10 @@ INSTALL(TARGETS ${EXECNAME}
   RUNTIME DESTINATION bin
 )
 
-
-
 #copy resources
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/pshare_test_scripts DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
 
-add_custom_command(TARGET copy_scripts POST_BUILD
+add_custom_command(TARGET pShare POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy_directory
                        ${CMAKE_SOURCE_DIR}/pshare_test_scripts ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})


### PR DESCRIPTION
The target didn't exist for pShare's cmake copy_script custom command. Resolved this be replacing with pShare to ensure test files are copied whenever pShare target is built.

See https://cmake.org/cmake/help/latest/command/add_custom_command.html#build-events