### PR TITLE
Bugfixes

### DIFF
--- a/Essentials/pMOOSBridge/MOOSUDPLink.cpp
+++ b/Essentials/pMOOSBridge/MOOSUDPLink.cpp
@@ -170,7 +170,8 @@ bool CMOOSUDPLink::ReadPktFromArray(unsigned char *pBuffer,int nBytes, CMOOSComm
     {
         if(q+nRqd<=nBytes)
         {
-            PktRx.Fill(pBuffer+q,nRqd);
+            memcpy(PktRx.NextWrite(), pBuffer+q, nRqd);
+            PktRx.OnBytesWritten(PktRx.NextWrite(), nRqd);
             q+=nRqd;
         }
         else

--- a/Essentials/pShare/Share.cpp
+++ b/Essentials/pShare/Share.cpp
@@ -16,7 +16,7 @@
 
 #include "MOOS/libMOOS/Utils/MOOSUtilityFunctions.h"
 #include "MOOS/libMOOS/Utils/IPV4Address.h"
-#include "MOOS/libMOOS/Thirdparty/getpot/getpot.h"
+#include "MOOS/libMOOS/Thirdparty/getpot/GetPot.hpp"
 #include "MOOS/libMOOS/Utils/SafeList.h"
 #include "MOOS/libMOOS/Utils/ConsoleColours.h"
 #include "MOOS/libMOOS/Utils/KeyboardCapture.h"


### PR DESCRIPTION
Replace the Fill method which was removed from MOOS previously.
Correct case of included header.