### PR TITLE
pShare: fix include path to GetPot

### DIFF
--- a/Essentials/pShare/CMakeLists.txt
+++ b/Essentials/pShare/CMakeLists.txt
@@ -17,7 +17,6 @@ INSTALL(TARGETS ${EXECNAME}
 #copy resources
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/pshare_test_scripts DESTINATION ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
 
-
 add_custom_command(TARGET pShare POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy_directory
-                       ${CMAKE_SOURCE_DIR}/pshare_test_scripts ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+                       ${CMAKE_CURRENT_SOURCE_DIR}/pshare_test_scripts ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})

--- a/Essentials/pShare/Share.cpp
+++ b/Essentials/pShare/Share.cpp
@@ -17,7 +17,7 @@
 
 #include "MOOS/libMOOS/Utils/MOOSUtilityFunctions.h"
 #include "MOOS/libMOOS/Utils/IPV4Address.h"
-#include "MOOS/libMOOS/Thirdparty/getpot/GetPot"
+#include "MOOS/libMOOS/Thirdparty/getpot/GetPot.hpp"
 #include "MOOS/libMOOS/Utils/SafeList.h"
 #include "MOOS/libMOOS/Utils/ConsoleColours.h"
 #include "MOOS/libMOOS/Utils/KeyboardCapture.h"


### PR DESCRIPTION
core-moos does not install the "GetPot" file and is therefore unavailable to include. This fixes it to include the file that is actually installed.